### PR TITLE
Provide the post ID during the solr_index_custom_fields filter

### DIFF
--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -214,16 +214,17 @@ class SolrPower_Sync {
 		$exclude_ids            = ( is_array( $plugin_s4wp_settings['s4wp_exclude_pages'] ) ) ? $plugin_s4wp_settings['s4wp_exclude_pages'] : explode( ',', $plugin_s4wp_settings['s4wp_exclude_pages'] );
 		$categoy_as_taxonomy    = $plugin_s4wp_settings['s4wp_cat_as_taxo'];
 		$index_comments         = $plugin_s4wp_settings['s4wp_index_comments'];
-		/**
-		 * Filter indexed custom fields
-		 *
-		 * Filter the list of custom field slugs available to index.
-		 *
-		 * @param array $index_custom_fields Array of custom field slugs for indexing.
-		 */
-		$index_custom_fields 	= apply_filters( 'solr_index_custom_fields', $plugin_s4wp_settings['s4wp_index_custom_fields'] );
 
 		if ( $post_info ) {
+
+			/**
+			 * Filter indexed custom fields
+			 *
+			 * Filter the list of custom field slugs available to index.
+			 *
+			 * @param array $index_custom_fields Array of custom field slugs for indexing.
+			 */
+			$index_custom_fields 	= apply_filters( 'solr_index_custom_fields', $plugin_s4wp_settings['s4wp_index_custom_fields'], $post_info->ID );
 
 			// check if we need to exclude this document.
 			if ( is_multisite() && in_array( substr( site_url(), 7 ) . $post_info->ID, (array) $exclude_ids ) ) {

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -679,7 +679,7 @@ class SolrPower_WP_Query {
 		 *
 		 * @param array $indexed_keys Array of custom field slugs for indexing.
 		 */
-		$indexed_keys = apply_filters( 'solr_index_custom_fields', $options['s4wp_index_custom_fields'] );
+		$indexed_keys = apply_filters( 'solr_index_custom_fields', $options['s4wp_index_custom_fields'], false );
 		$query        = array();
 		$relation     = 'AND'; // AND is default in core.
 		if ( isset( $meta_query['relation'] ) ) {


### PR DESCRIPTION
Moved the filter call inside the `if` block so we don't get null pointers, but otherwise should be self explanatory.